### PR TITLE
Updating gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "front-matter": "~1.0.0",
     "gulp-swig": "~0.7.4",
     "gulp-webserver": "~0.9.0",
-    "gulp-sass": "~1.3.3",
+    "gulp-sass": "~2.3.2",
     "gulp-concat": "~2.5.2",
     "gulp-uglify": "~1.2.0",
     "gulp-gh-pages": "~0.5.1"


### PR DESCRIPTION
The sass binaries for the version gulp-sass is using are no longer available.
